### PR TITLE
Fixed calculating user share target by using bignum

### DIFF
--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -86,13 +86,13 @@ var JobManager = module.exports = function JobManager(options){
     var diffDividend = (function(){
         switch(options.algorithm){
             case 'sha256':
-                return 0x00000000ffff0000000000000000000000000000000000000000000000000000;
+                return '00000000ffff0000000000000000000000000000000000000000000000000000';
             case 'scrypt':
             case 'scrypt-jane':
-                return 0x0000ffff00000000000000000000000000000000000000000000000000000000;
+                return '0000ffff00000000000000000000000000000000000000000000000000000000';
             case 'quark':
             case 'x11':
-                return 0x000000ffff000000000000000000000000000000000000000000000000000000;
+                return '000000ffff000000000000000000000000000000000000000000000000000000';
         }
     })();
 
@@ -214,7 +214,7 @@ var JobManager = module.exports = function JobManager(options){
             blockHash = util.reverseBuffer(util.doublesha(headerBuffer)).toString('hex');
         }
         else {
-            var targetUser = bignum(diffDividend / difficulty);
+            var targetUser = bignum(diffDividend, 16).div(difficulty);
             if (headerBigNum.gt(targetUser)){
                 return shareError([23, 'low difficulty share']);
             }


### PR DESCRIPTION
I was testing this on a dev server with cpuminer so I set difficulty to 1. The pool sometimes returned “low difficulty share” error for valid shares. I know this won't occur in real-life that often as difficulties are higher and it's less probable that submitted shares will be on the edge of the target, but it's still worth fixing it.

Floating arithmetics is only an estimation and if we want precise arithmetics then it's exactly what libs like bignum are for.
