### PR TITLE
Fixes to resolve proxy switching

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -687,7 +687,6 @@ var pool = module.exports = function pool(options, authorizeFn){
             function (clientsToRelinquish) {
                 clientsToRelinquish.forEach(function(cObj) {
                     cObj.client.removeAllListeners();
-                    cObj.client.socket.removeAllListeners();
                     _this.stratumServer.removeStratumClientBySubId(cObj.subId);
                 });
                 

--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -208,7 +208,6 @@ var StratumClient = function(options){
                         return;
                     }
 
-
                     if (messageJson) {
                         handleMessage(messageJson);
                     }
@@ -277,6 +276,12 @@ var StratumClient = function(options){
     this.manuallyAuthClient = function (username, password) {
         handleAuthorize({id: 1, params: [username, password]}, false /*do not reply to miner*/);
     }
+
+    this.manuallySetValues = function (otherClient) {
+        _this.extraNonce1        = otherClient.extraNonce1;
+        _this.previousDifficulty = otherClient.previousDifficulty;
+        _this.difficulty         = otherClient.difficulty;
+    }
 };
 StratumClient.prototype.__proto__ = events.EventEmitter.prototype;
 
@@ -296,7 +301,7 @@ var StratumServer = exports.Server = function StratumServer(ports, connectionTim
 
     var socketTimeout = connectionTimeout * 1000;
     var bannedMS = banning ? banning.time * 1000 : null;
-    
+
     var _this = this;
     var stratumClients = {};
     var subscriptionCounter = SubscriptionCounter();
@@ -338,6 +343,8 @@ var StratumServer = exports.Server = function StratumServer(ports, connectionTim
                 remoteAddress: socket.remoteAddress
             }
         );
+
+
         stratumClients[subscriptionId] = client;
         _this.emit('client.connected', client);
         client.on('socketDisconnect', function() {
@@ -403,6 +410,7 @@ var StratumServer = exports.Server = function StratumServer(ports, connectionTim
         var subId = _this.handleNewClient(clientObj.socket);
         if (subId != null) { // not banned!
             stratumClients[subId].manuallyAuthClient(clientObj.workerName, clientObj.workerPass);
+            stratumClients[subId].manuallySetValues(clientObj);
         }
     }
 


### PR DESCRIPTION
I'm still testing this completely, but the switching was getting hung up because the workers when moved to the new pool where not properly subscribed and setup; some of the previous settings on the client were lost during the move.

Restoring them did the trick.   This change goes with a similar PR for NOMP to handle the business end of the pool switching.
