### PR TITLE
Fix coinbase hashing for skein

### DIFF
--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -72,7 +72,6 @@ var JobManager = module.exports = function JobManager(options){
         switch(options.coin.algorithm){
             case 'keccak':
             case 'blake':
-            case 'skein':
             case 'fugue':
             case 'groestl':
                 if (options.coin.normalHashing === true)


### PR DESCRIPTION
Use sha256d to create the coinbase hash for skein (used in skeincoin and myriadcoin).
