### PR TITLE
Removed extra emit of started event

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -455,7 +455,6 @@ var pool = module.exports = function pool(options, authorizeFn){
             options.initStats.stratumPorts = Object.keys(options.ports);
             _this.stratumServer.broadcastMiningJobs(_this.jobManager.currentJob.getJobParams());
             finishedCallback();
-            _this.emit('started');
 
         }).on('broadcastTimeout', function(){
             emitLog('No new blocks for ' + options.jobRebroadcastTimeout + ' seconds - updating transactions & rebroadcasting work');


### PR DESCRIPTION
The pool was emitting two 'started' events upon initialization.  Removed the extra one. 

Forthcoming changes in NOMP to fix the starting diff will work best if only one event is fired.
