### PR TITLE
Support sha1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ May be working (needs additional testing):
 * ? *Fugue* (Fuguecoin [FC])
 * ? *Qubit* (Qubitcoin [Q2C], Myriadcoin [MYR])
 * ? *SHAvite-3* (INKcoin [INK])
+* ? *Sha1* (Sha1coin [SHA], Yaycoin [YAY])
 
 Not working currently:
 * *Groestl* - for Myriadcoin
@@ -83,7 +84,7 @@ npm update
 Create the configuration for your coin:
 
 Possible options for `algorithm`: *sha256, scrypt, scrypt-jane, scrypt-n, quark, x11, keccak, blake,
-skein, groestl, fugue, shavite3, hefty1, or qubit*.
+skein, groestl, fugue, shavite3, hefty1, qubit, or sha1*.
 
 ```javascript
 var myCoin = {

--- a/lib/algoProperties.js
+++ b/lib/algoProperties.js
@@ -60,6 +60,13 @@ var algos = module.exports = global.algos = {
             }
         }
     },
+    sha1: {
+        hash: function(){
+            return function(){
+                return multiHashing.sha1.apply(this, arguments);
+            }
+        }
+    },
     x11: {
         hash: function(){
             return function(){

--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -97,6 +97,7 @@ var JobManager = module.exports = function JobManager(options){
                     };
                 }
             case 'scrypt-n':
+            case 'sha1':
                 return function (d) {
                     return util.reverseBuffer(util.sha256d(d));
                 };


### PR DESCRIPTION
This is reviewed patch against #74.

After he posted it, the another coin using SHA1 (named Yaycoin) was born.
So it's better to name 'sha1' instead of 'sha1coin'.
