### PR TITLE
Prepare for getinfo() removal.

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -37,7 +37,7 @@ function DaemonInterface(daemons, logger){
     }
 
     function isOnline(callback){
-        cmd('getinfo', [], function(results){
+        cmd('getnetworkinfo', [], function(results){
             var allOnline = results.every(function(result){
                 return !results.error;
             });

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -146,7 +146,7 @@ var pool = module.exports = function pool(options, authorizeFn){
 
         var generateProgress = function(){
 
-            _this.daemon.cmd('getinfo', [], function(results) {
+            _this.daemon.cmd('getmininginfo', [], function(results) {
                 var blockCount = results.sort(function (a, b) {
                     return b.response.blocks - a.response.blocks;
                 })[0].response.blocks;
@@ -369,7 +369,7 @@ var pool = module.exports = function pool(options, authorizeFn){
         var batchRpcCalls = [
             ['validateaddress', [options.address]],
             ['getdifficulty', []],
-            ['getinfo', []],
+            ['getnetworkinfo', []],
             ['getmininginfo', []],
             ['submitblock', []]
         ];
@@ -422,12 +422,12 @@ var pool = module.exports = function pool(options, authorizeFn){
                 }
             })();
 
-            options.testnet = rpcResults.getinfo.testnet;
-            options.protocolVersion = rpcResults.getinfo.protocolversion;
+            options.testnet = (rpcResults.getmininginfo.chain == 'test' ? true : false);
+            options.protocolVersion = rpcResults.getnetworkinfo.protocolversion;
 
             options.initStats = {
-                connections: rpcResults.getinfo.connections,
-                difficulty: rpcResults.getinfo.difficulty * algos[options.coin.algorithm].multiplier,
+                connections: rpcResults.getnetworkinfo.connections,
+                difficulty: rpcResults.getmininginfo.difficulty * algos[options.coin.algorithm].multiplier,
                 networkHashRate: rpcResults.getmininginfo.networkhashps
             };
 


### PR DESCRIPTION
Transition from getinfo() to getblockchaininfo(), getnetworkinfo() and getwalletinfo(), since getinfo() is deprecated and will be fully removed in 0.16 release of Bitcoin Core.