### PR TITLE
update from pay-to-pubkey to pay-to-script-hash

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -275,9 +275,11 @@ exports.addressToScript = function(addr){
         throw new Error();
     }
 
+    // Format: [one-byte version][20-byte hash][4-byte checksum]
     var pubkey = decoded.slice(1,-4);
 
-    return Buffer.concat([new Buffer([0x76, 0xa9, 0x14]), pubkey, new Buffer([0x88, 0xac])]);
+    // Pay-to-Script-Hash
+    return Buffer.concat([new Buffer([0xa9, 0x14]), pubkey, new Buffer([0x87])]);
 };
 
 


### PR DESCRIPTION
This is to be able to utilize the latest script-to-hash addresses in bitcoin