### PR TITLE
Add support for p2sh, BIP32 and bech32 decoding

### DIFF
--- a/lib/algoProperties.js
+++ b/lib/algoProperties.js
@@ -80,6 +80,13 @@ var algos = module.exports = global.algos = {
             }
         }
     },
+    c11: {
+        hash: function(){
+            return function(){
+                return multiHashing.c11.apply(this, arguments);
+            }
+        }
+    },
     x11: {
         hash: function(){
             return function(){

--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -9,7 +9,7 @@ var util = require('./util.js');
  * The BlockTemplate class holds a single job.
  * and provides several methods to validate and submit it to the daemon coin
 **/
-var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, poolAddressScript, extraNoncePlaceholder, reward, txMessages, recipients){
+var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, poolAddressScript, extraNoncePlaceholder, reward, txMessages, recipients, network){
 
     //private members
 
@@ -71,7 +71,8 @@ var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, pool
         extraNoncePlaceholder,
         reward,
         txMessages,
-        recipients
+        recipients,
+        network
     );
 
     this.serializeCoinbase = function(extraNonce1, extraNonce2){

--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -123,7 +123,8 @@ var JobManager = module.exports = function JobManager(options){
             _this.extraNoncePlaceholder,
             options.coin.reward,
             options.coin.txMessages,
-            options.recipients
+            options.recipients,
+            options.network
         );
 
         _this.currentJob = tmpBlockTemplate;
@@ -158,7 +159,8 @@ var JobManager = module.exports = function JobManager(options){
             _this.extraNoncePlaceholder,
             options.coin.reward,
             options.coin.txMessages,
-            options.recipients
+            options.recipients,
+            options.network
         );
 
         this.currentJob = tmpBlockTemplate;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -273,7 +273,7 @@ var pool = module.exports = function pool(options, authorizeFn){
                 if (r.length === 40)
                     rObj.script = util.miningKeyToScript(r);
                 else
-                    rObj.script = util.addressToScript(r);
+                    rObj.script = util.addressToScript(options.network, r);
                 recipients.push(rObj);
                 options.feePercent += percent;
             }
@@ -414,16 +414,18 @@ var pool = module.exports = function pool(options, authorizeFn){
                 return;
             }
 
+            options.testnet = (rpcResults.getblockchaininfo.chain === 'test') ? true : false;
+
+            options.network = (options.testnet ? options.coin.testnet : options.coin.mainnet);
+
             options.poolAddressScript = (function(){
                 switch(options.coin.reward){
                     case 'POS':
                         return util.pubkeyToScript(rpcResults.validateaddress.pubkey);
                     case 'POW':
-                        return util.addressToScript(rpcResults.validateaddress.address);
+                        return util.addressToScript(options.network, rpcResults.validateaddress.address);
                 }
             })();
-
-            options.testnet = (rpcResults.getblockchaininfo.chain === 'test') ? true : false;
 
             options.protocolVersion = rpcResults.getnetworkinfo.protocolversion;
 

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -123,7 +123,7 @@ For some (probably outdated and incorrect) documentation about whats kinda going
 see: https://en.bitcoin.it/wiki/Protocol_specification#tx
  */
 
-var generateOutputTransactions = function(poolRecipient, recipients, rpcData){
+var generateOutputTransactions = function(poolRecipient, recipients, rpcData, network){
 
     var reward = rpcData.coinbasevalue;
     var rewardToPool = reward;
@@ -132,52 +132,52 @@ var generateOutputTransactions = function(poolRecipient, recipients, rpcData){
 
 
 
-/* Dash 12.1 */
-if (rpcData.masternode && rpcData.superblock) {
-    if (rpcData.masternode.payee) {
-        var payeeReward = 0;
-
-        payeeReward = rpcData.masternode.amount;
-        reward -= payeeReward;
-        rewardToPool -= payeeReward;
-
-        var payeeScript = util.addressToScript(rpcData.masternode.payee);
-        txOutputBuffers.push(Buffer.concat([
-            util.packInt64LE(payeeReward),
-            util.varIntBuffer(payeeScript.length),
-            payeeScript
-        ]));
-    } else if (rpcData.superblock.length > 0) {
-        for(var i in rpcData.superblock){
+    /* Dash 12.1 */
+    if (rpcData.masternode && rpcData.superblock) {
+        if (rpcData.masternode.payee) {
             var payeeReward = 0;
 
-            payeeReward = rpcData.superblock[i].amount;
+            payeeReward = rpcData.masternode.amount;
             reward -= payeeReward;
             rewardToPool -= payeeReward;
 
-            var payeeScript = util.addressToScript(rpcData.superblock[i].payee);
+            var payeeScript = util.addressToScript(network, rpcData.masternode.payee);
             txOutputBuffers.push(Buffer.concat([
                 util.packInt64LE(payeeReward),
                 util.varIntBuffer(payeeScript.length),
                 payeeScript
             ]));
+        } else if (rpcData.superblock.length > 0) {
+            for(var i in rpcData.superblock){
+                var payeeReward = 0;
+
+                payeeReward = rpcData.superblock[i].amount;
+                reward -= payeeReward;
+                rewardToPool -= payeeReward;
+
+                var payeeScript = util.addressToScript(network, rpcData.superblock[i].payee);
+                txOutputBuffers.push(Buffer.concat([
+                    util.packInt64LE(payeeReward),
+                    util.varIntBuffer(payeeScript.length),
+                    payeeScript
+                ]));
+            }
         }
     }
-}
 
-if (rpcData.payee) {
-    var payeeReward = 0;
+    if (rpcData.payee) {
+        var payeeReward = 0;
 
-    if (rpcData.payee_amount) {
-        payeeReward = rpcData.payee_amount;
-    } else {
-        payeeReward = Math.ceil(reward / 5);
-    }
+        if (rpcData.payee_amount) {
+            payeeReward = rpcData.payee_amount;
+        } else {
+            payeeReward = Math.ceil(reward / 5);
+        }
 
         reward -= payeeReward;
         rewardToPool -= payeeReward;
 
-        var payeeScript = util.addressToScript(rpcData.payee);
+        var payeeScript = util.addressToScript(network, rpcData.payee);
         txOutputBuffers.push(Buffer.concat([
             util.packInt64LE(payeeReward),
             util.varIntBuffer(payeeScript.length),
@@ -222,7 +222,7 @@ if (rpcData.payee) {
 };
 
 
-exports.CreateGeneration = function(rpcData, publicKey, extraNoncePlaceholder, reward, txMessages, recipients){
+exports.CreateGeneration = function(rpcData, publicKey, extraNoncePlaceholder, reward, txMessages, recipients, network){
 
     var txInputsCount = 1;
     var txOutputsCount = 1;
@@ -272,7 +272,7 @@ exports.CreateGeneration = function(rpcData, publicKey, extraNoncePlaceholder, r
      */
 
 
-    var outputTransactions = generateOutputTransactions(publicKey, recipients, rpcData);
+    var outputTransactions = generateOutputTransactions(publicKey, recipients, rpcData, network);
 
     var p2 = Buffer.concat([
         scriptSigPart2,

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,6 +2,7 @@ var crypto = require('crypto');
 
 var base58 = require('base58-native');
 var bignum = require('bignum');
+var bitcoin = require('bitcoinjs-lib');
 
 
 exports.addressFromEx = function(exAddress, ripdm160Key){
@@ -261,25 +262,15 @@ exports.miningKeyToScript = function(key){
 /*
 For POW coins - used to format wallet address for use in generation transaction's output
  */
-exports.addressToScript = function(addr){
+exports.addressToScript = function(network, addr){
 
-    var decoded = base58.decode(addr);
-
-    if (decoded.length != 25){
-        console.error('invalid address length for ' + addr);
-        throw new Error();
+    if (typeof network !== 'undefined' && network !== null){
+        return bitcoin.address.toOutputScript(addr, network);
+    } else {
+        return Buffer.concat([new Buffer([0x76, 0xa9, 0x14]), bitcoin.address.fromBase58Check(addr).hash, new Buffer([0x88, 0xac])]);
     }
 
-    if (!decoded){
-        console.error('base58 decode failed for ' + addr);
-        throw new Error();
-    }
-
-    var pubkey = decoded.slice(1,-4);
-
-    return Buffer.concat([new Buffer([0x76, 0xa9, 0x14]), pubkey, new Buffer([0x88, 0xac])]);
 };
-
 
 exports.getReadableHashRateString = function(hashrate){
     var i = -1;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     },
     "dependencies": {
         "multi-hashing": "git://github.com/zone117x/node-multi-hashing.git",
+        "bitcoinjs-lib": "*",
         "bignum": "*",
         "base58-native": "*",
         "async": "*"


### PR DESCRIPTION
Introduce new (optional) network parameter for detection of the key version and extraction of the corresponding coinbase output script. Values can be added for example in coin.json of NOMP (first to be introduced in dev branch). When not found, we are assuming to deal with a legacy address and perform standard base58 decoding.

Determination of the key version is done by bitcoins-lib. Subsequently we can further refactor the code by passing more tasks to this library.

Examples for blocks mined with the change included:

[network parameters added, coinbase = legacy](http://54.37.18.226:3001/tx/12cd73ac36c5e2f6659b3285db647eaee85598c6347a511a225ad7ce7cd2bd63)

[network parameters added, coinbase = p2sh-segwit & legacy](http://54.37.18.226:3001/tx/af417508f76c8c5cf0f9162a8d46ae0eb99170ea0b0b67bc9b70e27052cde1bc)

[network parameters added, coinbase = bech32 & legacy](http://54.37.18.226:3001/tx/45b8a75bbbaf2f123f4a7ad7aeb57ae407e6946bc055babf9c19dffba1f1dd72)

and finally:
[no parameters added, coinbase = legacy](http://54.37.18.226:3001/tx/a35318d157a07918c88b1ba9debc804bf0a9df51bc717fef8f90f7ec47cc252d)