### PR TITLE
Fixed block header

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -94,7 +94,7 @@ var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, pool
         header.write(nTime, position += 4, 4, 'hex');
         header.write(merkleRoot, position += 4, 32, 'hex');
         header.write(rpcData.previousblockhash, position += 32, 32, 'hex');
-        header.writeUInt32BE(rpcData.version, position + 32);
+        header.writeInt32BE(rpcData.version, position + 32);
         var header = util.reverseBuffer(header);
         return header;
     };


### PR DESCRIPTION
Error generated in blockTemplate caused by use of UInt32 for a Int32 value.


buffer.js:784
    throw TypeError('value is out of bounds');
          ^
TypeError: value is out of bounds
    at TypeError (<anonymous>)
    at checkInt (buffer.js:784:11)
    at Buffer.writeUInt32BE (buffer.js:848:5)
    at BlockTemplate.serializeHeader (/home/ubuntu/stratum-server/node_modules/stratum-pool/lib/blockTemplate.js:97:16)
    at JobManager.processShare (/home/ubuntu/stratum-server/node_modules/stratum-pool/lib/jobManager.js:224:32)
    at null.<anonymous> (/home/ubuntu/stratum-server/node_modules/stratum-pool/lib/pool.js:506:46)
    at EventEmitter.emit (events.js:117:20)
    at handleSubmit (/home/ubuntu/stratum-server/node_modules/stratum-pool/lib/stratum.js:159:15)
    at handleMessage (/home/ubuntu/stratum-server/node_modules/stratum-pool/lib/stratum.js:72:17)
    at /home/ubuntu/stratum-server/node_modules/stratum-pool/lib/stratum.js:232:25

