### PR TITLE
Add compatibility with Dash v0.13

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -183,7 +183,7 @@ var generateOutputTransactions = function(poolRecipient, recipients, rpcData){
     /* End Dash 0.12.1/0.13 */
 
     if (rpcData.payee) {
-	var payeeReward = 0;
+	    var payeeReward = 0;
 
         if (rpcData.payee_amount) {
             payeeReward = rpcData.payee_amount;
@@ -244,7 +244,17 @@ exports.CreateGeneration = function(rpcData, publicKey, extraNoncePlaceholder, r
     var txInputsCount = 1;
     var txOutputsCount = 1;
     var txVersion = txMessages === true ? 2 : 1;
+    var txType = 0;
+    var txExtraPayload;
     var txLockTime = 0;
+
+    if (rpcData.coinbase_payload && rpcData.coinbase_payload.length > 0) {
+        txVersion = 3;
+        txType = 5;
+        txExtraPayload = new Buffer(rpcData.coinbase_payload, 'hex');
+    }
+
+    txVersion = txVersion + (txType << 16);
 
     var txInPrevOutHash = "";
     var txInPrevOutIndex = Math.pow(2, 32) - 1;
@@ -303,6 +313,14 @@ exports.CreateGeneration = function(rpcData, publicKey, extraNoncePlaceholder, r
         util.packUInt32LE(txLockTime),
         txComment
     ]);
+
+    if (txExtraPayload !== undefined) {
+        var p2 = Buffer.concat([
+            p2,
+            util.varIntBuffer(txExtraPayload.length),
+            txExtraPayload
+        ]);
+    }
 
     return [p1, p2];
 

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -147,7 +147,7 @@ var generateOutputTransactions = function(poolRecipient, recipients, rpcData){
                 payeeScript
             ]));
         } else if (rpcData.masternode.length > 0) {
-            for(var i in rpcData.masternode) {
+            for (var i = 0; i < rpcData.masternode.length; i++) {
                 var payeeReward = 0;
 
                 payeeReward = rpcData.masternode[i].amount;
@@ -172,7 +172,7 @@ var generateOutputTransactions = function(poolRecipient, recipients, rpcData){
     }
 
     if (rpcData.superblock && rpcData.superblock.length > 0) {
-        for(var i in rpcData.superblock){
+        for (var i = 0; i < rpcData.superblock.length; i++) {
             var payeeReward = 0;
 
             payeeReward = rpcData.superblock[i].amount;

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -131,23 +131,40 @@ var generateOutputTransactions = function(poolRecipient, recipients, rpcData){
     var txOutputBuffers = [];
 
 
+    /* Dash 0.12.1/0.13 */
+    if (rpcData.masternode) {
+        if (rpcData.masternode.payee) {
+            var payeeReward = 0;
 
-/* Dash 12.1 */
-if (rpcData.masternode && rpcData.superblock) {
-    if (rpcData.masternode.payee) {
-        var payeeReward = 0;
+            payeeReward = rpcData.masternode.amount;
+            reward -= payeeReward;
+            rewardToPool -= payeeReward;
 
-        payeeReward = rpcData.masternode.amount;
-        reward -= payeeReward;
-        rewardToPool -= payeeReward;
+            var payeeScript = util.addressToScript(rpcData.masternode.payee);
+            txOutputBuffers.push(Buffer.concat([
+                util.packInt64LE(payeeReward),
+                util.varIntBuffer(payeeScript.length),
+                payeeScript
+            ]));
+        } else if (rpcData.masternode.length > 0) {
+            for(var i in rpcData.masternode) {
+                var payeeReward = 0;
 
-        var payeeScript = util.addressToScript(rpcData.masternode.payee);
-        txOutputBuffers.push(Buffer.concat([
-            util.packInt64LE(payeeReward),
-            util.varIntBuffer(payeeScript.length),
-            payeeScript
-        ]));
-    } else if (rpcData.superblock.length > 0) {
+                payeeReward = rpcData.masternode[i].amount;
+                reward -= payeeReward;
+                rewardToPool -= payeeReward;
+
+                var payeeScript = util.addressToScript(rpcData.masternode[i].payee);
+                txOutputBuffers.push(Buffer.concat([
+                    util.packInt64LE(payeeReward),
+                    util.varIntBuffer(payeeScript.length),
+                    payeeScript
+                ]));
+            }
+        }
+    }
+
+    if (rpcData.superblock && rpcData.superblock.length > 0) {
         for(var i in rpcData.superblock){
             var payeeReward = 0;
 
@@ -163,16 +180,16 @@ if (rpcData.masternode && rpcData.superblock) {
             ]));
         }
     }
-}
+    /* End Dash 0.12.1/0.13 */
 
-if (rpcData.payee) {
-    var payeeReward = 0;
+    if (rpcData.payee) {
+	var payeeReward = 0;
 
-    if (rpcData.payee_amount) {
-        payeeReward = rpcData.payee_amount;
-    } else {
-        payeeReward = Math.ceil(reward / 5);
-    }
+        if (rpcData.payee_amount) {
+            payeeReward = rpcData.payee_amount;
+        } else {
+            payeeReward = Math.ceil(reward / 5);
+        }
 
         reward -= payeeReward;
         rewardToPool -= payeeReward;

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -154,7 +154,14 @@ var generateOutputTransactions = function(poolRecipient, recipients, rpcData){
                 reward -= payeeReward;
                 rewardToPool -= payeeReward;
 
-                var payeeScript = util.addressToScript(rpcData.masternode[i].payee);
+                var payeeScript;
+
+                if (rpcData.masternode[i].script) {
+                    payeeScript = new Buffer(rpcData.masternode[i].script, 'hex');
+                } else {
+                    payeeScript = util.addressToScript(rpcData.masternode[i].payee);
+                }
+
                 txOutputBuffers.push(Buffer.concat([
                     util.packInt64LE(payeeReward),
                     util.varIntBuffer(payeeScript.length),
@@ -172,7 +179,14 @@ var generateOutputTransactions = function(poolRecipient, recipients, rpcData){
             reward -= payeeReward;
             rewardToPool -= payeeReward;
 
-            var payeeScript = util.addressToScript(rpcData.superblock[i].payee);
+            var payeeScript;
+
+            if (rpcData.superblock[i].script) {
+                payeeScript = new Buffer(rpcData.superblock[i].script, 'hex');
+            } else {
+                payeeScript = util.addressToScript(rpcData.superblock[i].payee);
+            }
+
             txOutputBuffers.push(Buffer.concat([
                 util.packInt64LE(payeeReward),
                 util.varIntBuffer(payeeScript.length),


### PR DESCRIPTION
Tested similar patch as a part of unomp https://github.com/UNOMP/node-merged-pool/pull/17, so I _think_ this one should work fine too. At least there should be no difference between the two when comparing them side by side with `&w=1`.