### PR TITLE
Fix for COINBASE_FLAGS removed in Bitcoin v0.20.0

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -245,7 +245,7 @@ exports.CreateGeneration = function(rpcData, publicKey, extraNoncePlaceholder, r
 
     var scriptSigPart1 = Buffer.concat([
         util.serializeNumber(rpcData.height),
-        new Buffer(rpcData.coinbaseaux.flags, 'hex'),
+        new Buffer([]),
         util.serializeNumber(Date.now() / 1000 | 0),
         new Buffer([extraNoncePlaceholder.length])
     ]);


### PR DESCRIPTION
Bitcoin removed COINBASE_FLAGS in v0.20.0.
Therefore, `rpcData.coinbaseaux.flags` will be an error.

Bitcoin commits:
https://github.com/bitcoin/bitcoin/commit/e9a27cf338dc618b8ecab8984abc54d588de8a05#diff-9651347c8e00bed3ddc7631de569406dL610
