### PR TITLE
Updated pool and util to support p2sh-segwit type of address

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -421,9 +421,9 @@ var pool = module.exports = function pool(options, authorizeFn){
             options.poolAddressScript = (function(){
                 switch(options.coin.reward){
                     case 'POS':
-                        return util.pubkeyToScript(rpcResults.validateaddress.pubkey);
+                        return util.pubkeyToScript(rpcResults.validateaddress.pubkey, rpcResults.validateaddress.isscript);
                     case 'POW':
-                        return util.addressToScript(rpcResults.validateaddress.address);
+                        return util.addressToScript(rpcResults.validateaddress.address, rpcResults.validateaddress.isscript);
                 }
             })();
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -261,7 +261,7 @@ exports.miningKeyToScript = function(key){
 /*
 For POW coins - used to format wallet address for use in generation transaction's output
  */
-exports.addressToScript = function(addr){
+exports.addressToScript = function(addr, p2shSupportedAddr = false){
 
     var decoded = base58.decode(addr);
 
@@ -276,6 +276,9 @@ exports.addressToScript = function(addr){
     }
 
     var pubkey = decoded.slice(1,-4);
+
+    if(p2shSupportedAddr)
+	return Buffer.concat([new Buffer([0xa9, 0x14]), pubkey, new Buffer([0x87])]);
 
     return Buffer.concat([new Buffer([0x76, 0xa9, 0x14]), pubkey, new Buffer([0x88, 0xac])]);
 };


### PR DESCRIPTION
Added support for p2sh-segwit address.
While setting up for my test mining pool, I faced the issue of **block rewards going to random addresses when using p2sh-segwit**, so had to use legacy address. Thanks to [this reply](https://github.com/zone117x/node-open-mining-portal/issues/661#issuecomment-588971219) and after confirming from [this golang adaption](https://github.com/mining-pool/not-only-mining-pool/blob/07a8cb09116b81bc1e89258234f451cd9b7eef3a/utils/utils.go#L315), added the support.
The changes are tested locally and confirmed to be working as expected.

Thanks