### PR TITLE
Respond with PONG to prevent P2P disconnection

### DIFF
--- a/lib/peer.js
+++ b/lib/peer.js
@@ -72,7 +72,9 @@ var Peer = module.exports = function (options) {
         inv: commandStringBuffer('inv'),
         verack: commandStringBuffer('verack'),
         addr: commandStringBuffer('addr'),
-        getblocks: commandStringBuffer('getblocks')
+        getblocks: commandStringBuffer('getblocks'),
+        ping: commandStringBuffer('ping'),
+        pong: commandStringBuffer('pong'),
     };
 
 
@@ -191,6 +193,9 @@ var Peer = module.exports = function (options) {
             case commands.version.toString():
                 SendMessage(commands.verack, Buffer.alloc(0));
                 break;
+            // Prevent peer disconnection by returning pong https://en.bitcoin.it/wiki/Protocol_documentation#ping
+            case commands.ping.toString():
+                SendMessage(commands.pong, payload);
             default:
                 break;
         }


### PR DESCRIPTION
Should return the pong command along with the received nonce as per specification.

This should also fix the p2p connections being disconnected and would allow keeping a constant connections.